### PR TITLE
Allow multiple months of precipitation to go into each yield estimate

### DIFF
--- a/src/Agriculture.jl
+++ b/src/Agriculture.jl
@@ -133,7 +133,7 @@ function initagriculture(m::Model)
 
     # Sum precip to a yearly level
     stepsperyear = floor(Int64, 12 / config["timestep"])
-    rollingsum = cumsum(precip, 2) - cumsum([zeros(numcounties, stepsperyear) precip[:, 1:size(precip)[2] - stepsperyear]])
+    rollingsum = cumsum(precip, 2) - cumsum([zeros(numcounties, stepsperyear) precip[:, 1:size(precip)[2] - stepsperyear]],2)
     agriculture[:precipitation] = rollingsum
 
     # Load in planted area by water management

--- a/src/Agriculture.jl
+++ b/src/Agriculture.jl
@@ -130,7 +130,11 @@ function initagriculture(m::Model)
     agriculture[:logirrigatedyield] = logirrigatedyield
     agriculture[:deficit_coeff] = deficit_coeff
     agriculture[:water_demand] = water_demand
-    agriculture[:precipitation] = precip
+
+    # Sum precip to a yearly level
+    stepsperyear = floor(Int64, 12 / config["timestep"])
+    rollingsum = cumsum(precip, 2) - cumsum([zeros(numregions, stepsperyear) precip[:, 1:size(precip)[2] - stepsperyear]])
+    agriculture[:precipitation] = rollingsum
 
     # Load in planted area by water management
     rainfeds = readtable(joinpath(todata, "agriculture/rainfedareas.csv"))

--- a/src/Agriculture.jl
+++ b/src/Agriculture.jl
@@ -133,7 +133,7 @@ function initagriculture(m::Model)
 
     # Sum precip to a yearly level
     stepsperyear = floor(Int64, 12 / config["timestep"])
-    rollingsum = cumsum(precip, 2) - cumsum([zeros(numregions, stepsperyear) precip[:, 1:size(precip)[2] - stepsperyear]])
+    rollingsum = cumsum(precip, 2) - cumsum([zeros(numcounties, stepsperyear) precip[:, 1:size(precip)[2] - stepsperyear]])
     agriculture[:precipitation] = rollingsum
 
     # Load in planted area by water management


### PR DESCRIPTION
The total production to use should then be the maximum over any year of whatever periods are in that year.  Since the market is also saturated on a monthly timestep, this allows the whole agriculture and market system to work as almost-expected.  We still should have agriculture just run on a different timestep, so it doesn't report producing yield every month, but that can wait for the `agtimefix` branch to be ready.