### PR TITLE
Move agricultural prices to a dictionary in the lib/agriculture.jl library

### DIFF
--- a/src/Market.jl
+++ b/src/Market.jl
@@ -64,15 +64,7 @@ Add a market component to the model.
 function initmarket(m::Model)
     market = addcomponent(m, Market)
 
-    prices = [102.51 / 2204.62, # alfalfa
-              102.51 / 2204.62, # otherhay
-              120.12 * .021772, # barley
-              120.12 * .021772, # barley.winter
-              160.63 * .0254, # maize
-              174.90 / 2204.62, # sorghum: $/MT / lb/MT
-              349.52 * .0272155, # soybeans
-              5.1675, # wheat
-              171.50 * .0272155] # wheat.winter
+    prices = crop_information(allcrops, crop_prices, 0, warnonmiss=true)
 
     market[:produced] = repeat([0.], outer=[m.indices_counts[:regions], m.indices_counts[:allcrops], m.indices_counts[:time]])
     market[:domestic_prices] = repeat(transpose(prices), outer=[m.indices_counts[:regions], 1])

--- a/src/lib/agriculture.jl
+++ b/src/lib/agriculture.jl
@@ -198,7 +198,7 @@ else
 end
 
 alluniquecrops = ["barley", "corn", "sorghum", "soybeans", "wheat", "hay"]
-uniquemapping = Dict{AbstractString, Vector{AbstractString}}("barley" => ["Barley", "Barley.Winter"], "corn" => ["Maize", "maize"], "sorghum" => ["Sorghum"], "soybeans" => ["Soybeans"], "wheat" => ["Wheat", "Wheat.Winter"], "hay" => ["alfalfa", "otherhay"], "Barley" => "barley", "Barley.Winter" => "barley", "Maize" => ["maize", "corn"], "maize" => ["Maize", "corn"], "Sorghum" => ["sorghum"], "Soybeans" => ["soybeans"], "Wheat" => ["wheat"], "alfalfa" => ["hay"], "otherhay" => ["hay"])
+uniquemapping = Dict{AbstractString, Vector{AbstractString}}("barley" => ["Barley", "Barley.Winter"], "corn" => ["Maize", "maize"], "sorghum" => ["Sorghum"], "soybeans" => ["Soybeans"], "wheat" => ["Wheat", "Wheat.Winter"], "hay" => ["alfalfa", "otherhay"], "Barley" => ["barley"], "Barley.Winter" => ["barley"], "Maize" => ["maize", "corn"], "maize" => ["Maize", "corn"], "Sorghum" => ["sorghum"], "Soybeans" => ["soybeans"], "Wheat" => ["wheat"], "alfalfa" => ["hay"], "otherhay" => ["hay"])
 
 """
 Determine which crops are not represented

--- a/src/lib/agriculture.jl
+++ b/src/lib/agriculture.jl
@@ -292,14 +292,14 @@ end
 """
 Collect all crop info from one of the dictionaries, aware of name changes
 """
-function crop_information(crops::Vector{AbstractString}, dict, default, warnonmiss=false)
+function crop_information(crops::Vector{Any}, dict, default; warnonmiss=false)
     [crop_information(crop, dict, default, warnonmiss=warnonmiss) for crop in crops]
 end
 
 """
 Collect single crop info from one of the dictionaries, aware of name changes
 """
-function crop_information(crop::AbstractString, dict, default, warnonmiss=false)
+function crop_information(crop::AbstractString, dict, default; warnonmiss=false)
     if crop in keys(dict)
         return dict[crop]
     else

--- a/src/lib/agriculture.jl
+++ b/src/lib/agriculture.jl
@@ -44,6 +44,16 @@ maximum_yields = Dict("alfalfa" => 25., "otherhay" => 25., "Hay" => 306,
                       "sorghum" => 150., "soybeans" => 100.,
 "wheat" => 250., "hay" => 306.)
 
+crop_prices = Dict("alfalfa" => 102.51 / 2204.62, # alfalfa
+                   "otherhay" => 102.51 / 2204.62, # otherhay
+                   "Barley" => 120.12 * .021772, # barley
+                   "Barley.Winter" => 120.12 * .021772, # barley.winter
+                   "Maize" => 160.63 * .0254, # maize
+                   "Sorghum" => 174.90 / 2204.62, # sorghum: $/MT / lb/MT
+                   "Soybeans" => 349.52 * .0272155, # soybeans
+                   "Wheat" => 5.1675, # wheat
+                   "Wheat.Winter" => 171.50 * .0272155) # wheat.winter
+
 quickstats_planted = Dict("corn.co.rainfed" => "agriculture/allyears/maize-nonirrigated-planted.csv",
                           "corn.co.irrigated" => "agriculture/allyears/maize-irrigated-planted.csv",
                           "wheat.co.rainfed" => "agriculture/allyears/wheat-nonirrigated-planted.csv",
@@ -188,7 +198,7 @@ else
 end
 
 alluniquecrops = ["barley", "corn", "sorghum", "soybeans", "wheat", "hay"]
-uniquemapping = Dict{AbstractString, Vector{AbstractString}}("barley" => ["Barley", "Barley.Winter"], "corn" => ["Maize"], "sorghum" => ["Sorghum"], "soybeans" => ["Soybeans"], "wheat" => ["Wheat", "Wheat.Winter"], "hay" => ["alfalfa", "otherhay"])
+uniquemapping = Dict{AbstractString, Vector{AbstractString}}("barley" => ["Barley", "Barley.Winter"], "corn" => ["Maize", "maize"], "sorghum" => ["Sorghum"], "soybeans" => ["Soybeans"], "wheat" => ["Wheat", "Wheat.Winter"], "hay" => ["alfalfa", "otherhay"], "Barley" => "barley", "Barley.Winter" => "barley", "Maize" => ["maize", "corn"], "maize" => ["Maize", "corn"], "Sorghum" => ["sorghum"], "Soybeans" => ["soybeans"], "Wheat" => ["wheat"], "alfalfa" => ["hay"], "otherhay" => ["hay"])
 
 """
 Determine which crops are not represented
@@ -277,4 +287,32 @@ function read_quickstats(filepath::AbstractString)
     result[indices[indices .> 0]] = df[:xvalue][indices .> 0]
 
     result
+end
+
+"""
+Collect all crop info from one of the dictionaries, aware of name changes
+"""
+function crop_information(crops::Vector{AbstractString}, dict, default, warnonmiss=false)
+    [crop_information(crop, dict, default, warnonmiss=warnonmiss) for crop in crops]
+end
+
+"""
+Collect single crop info from one of the dictionaries, aware of name changes
+"""
+function crop_information(crop::AbstractString, dict, default, warnonmiss=false)
+    if crop in keys(dict)
+        return dict[crop]
+    else
+        for othername in uniquemapping[crop]
+            if othername in keys(dict)
+                return dict[othername]
+            end
+        end
+    end
+
+    if warnonmiss
+        warn("Could not find crop information for $crop.")
+    end
+
+    return default
 end


### PR DESCRIPTION
This also introduces a new function, `crop_information`, which is meant to be able to find the information for each crop from a dictionary, even if the names don't match exactly (e.g., when asked for "corn", it will also look for "maize" and "Maize")/